### PR TITLE
Allow setting basic authentication

### DIFF
--- a/browsermobproxy/client.py
+++ b/browsermobproxy/client.py
@@ -113,6 +113,19 @@ class Client(object):
                          urlencode({'regex': regexp, 'status': status_code}))
         return r.status_code
 
+    def basic_authentication(self, domain, username, password):
+        """
+        This add automatic basic authentication
+        :Args:
+         - domain: domain to set authentication credentials for
+         - username: valid username to use when authenticating
+         - password: valid password to use when authenticating
+         """
+        r = requests.post(url='%s/proxy/%s/auth/basic/%s' % (self.host, self.port, domain),
+                          data=json.dumps({'username': username, 'password': password}),
+                          headers={'content-type': 'application/json'})
+        return r.status_code
+
     LIMITS = {
         'upstream_kbps': 'upstreamKbps',
         'downstream_kbps': 'downstreamKbps',

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -102,6 +102,14 @@ class TestClient(object):
         status_code = self.client.blacklist("http://www\\.facebook\\.com/.*", 200)
         assert(status_code == 200)
 
+    def test_basic_authentication(self):
+        """
+        /proxy/:port/auth/basic
+        adds automatic basic authentication
+        """
+        status_code = self.client.basic_authentication("www.example.com", "myUsername", "myPassword")
+        assert(status_code == 200)
+
     def test_limits_invalid_key(self):
         """
         /proxy/:port/limits


### PR DESCRIPTION
This is dependent on the landing (and subsequent release) of https://github.com/webmetrics/browsermob-proxy/pull/84
