### PR TITLE
Check for browsermob-proxy exec on path and add chrome example

### DIFF
--- a/browsermobproxy/server.py
+++ b/browsermobproxy/server.py
@@ -9,7 +9,7 @@ from client import Client
 
 class Server(object):
 
-    def __init__(self, path, options={}):
+    def __init__(self, path = 'browsermob-proxy', options={}):
         """
         Initialises a Server object
 
@@ -19,11 +19,19 @@ class Server(object):
                      More items will be added in the future.
                      This defaults to an empty dictionary
         """
+        path_var_sep = ':'
         if platform.system() == 'Windows':
+            path_var_sep = ';'
             if not path.endswith('.bat'):
                 path += '.bat'
 
-        if not os.path.isfile(path):
+        exec_not_on_path = True
+        for directory in os.environ['PATH'].split(path_var_sep):
+            if(os.path.isfile(os.path.join(directory, path))):
+                exec_not_on_path = False
+                break
+
+        if not os.path.isfile(path) and exec_not_on_path:
             raise Exception("Browsermob-Proxy binary couldn't be found in path"
                             " provided: %s" % path)
 

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,14 @@ driver.quit()
 
 ```
 
+for Chrome use
+
+```
+chrome_options = webdriver.ChromeOptions()
+chrome_options.add_argument("--proxy-server={0}".format(proxy.proxy))
+browser = webdriver.Chrome(chrome_options = chrome_options)
+```
+
 Running Tests
 -------------
 To run the tests in a CI environment, disable the ones that require human


### PR DESCRIPTION
Was writing something using this library and thought it would be convenient if the server constructor looked on my PATH for the exec.  Also used the Chrome selenium driver which required a slightly different method than the firefox one, so thought it might be handy to have that example here as well.

Couldn't think of a simple way to add a test for this, but I can think a bit harder if needed. 
