### PR TITLE
Allow use of a remote proxy server.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - 3.3
   - 3.4
 before_script:
+  - sudo apt-get update
   - sudo apt-get install -y unzip
   - curl -k -L -O https://github.com/lightbody/browsermob-proxy/releases/download/browsermob-proxy-2.0.0/browsermob-proxy-2.0.0-bin.zip
   - unzip browsermob-proxy-2.0-beta-9-bin.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ before_script:
   - sudo apt-get update
   - sudo apt-get install -y unzip
   - curl -k -L -O https://github.com/lightbody/browsermob-proxy/releases/download/browsermob-proxy-2.0.0/browsermob-proxy-2.0.0-bin.zip
-  - unzip browsermob-proxy-2.0-beta-9-bin.zip
-  - export BROWSERMOB_PROXY_HOME=`pwd`/browsermob-proxy-2.0.0-bin
+  - unzip browsermob-proxy-2.0.0-bin.zip
+  - export BROWSERMOB_PROXY_HOME=`pwd`/browsermob-proxy-2.0.0
   - sh $BROWSERMOB_PROXY_HOME/bin/browsermob-proxy --port=9090 &
   - sleep 5
 install: pip install pytest selenium

--- a/browsermobproxy/__init__.py
+++ b/browsermobproxy/__init__.py
@@ -1,6 +1,6 @@
 __version__ = '0.5.0'
 
-from .server import Server
+from .server import RemoteServer, Server
 from .client import Client
 
-__all__ = ['Server', 'Client', 'browsermobproxy']
+__all__ = ['RemoteServer', 'Server', 'Client', 'browsermobproxy']

--- a/browsermobproxy/server.py
+++ b/browsermobproxy/server.py
@@ -7,7 +7,48 @@ import time
 from .client import Client
 
 
-class Server(object):
+class RemoteServer(object):
+
+    def __init__(self, host, port):
+        """
+        Initialises a RemoteServer object
+
+        :param host: The host of the proxy server.
+        :param port: The port of the proxy server.
+        """
+        self.host = host
+        self.port = port
+
+    @property
+    def url(self):
+        """
+        Gets the url that the proxy is running on. This is not the URL clients
+        should connect to.
+        """
+        return "http://%s:%d" % (self.host, self.port)
+
+    def create_proxy(self, params={}):
+        """
+        Gets a client class that allow to set all the proxy details that you
+        may need to.
+        :param params: Dictionary where you can specify params \
+                    like httpProxy and httpsProxy
+        """
+        client = Client(self.url[7:], params)
+        return client
+
+    def _is_listening(self):
+        try:
+            socket_ = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            socket_.settimeout(1)
+            socket_.connect((self.host, self.port))
+            socket_.close()
+            return True
+        except socket.error:
+            return False
+
+
+class Server(RemoteServer):
 
     def __init__(self, path='browsermob-proxy', options={}):
         """
@@ -35,6 +76,7 @@ class Server(object):
                             " provided: %s" % path)
 
         self.path = path
+        self.host = 'localhost'
         self.port = options.get('port', 8080)
         self.process = None
 
@@ -76,31 +118,3 @@ class Server(object):
             pass
 
         self.log_file.close()
-
-    @property
-    def url(self):
-        """
-        Gets the url that the proxy is running on. This is not the URL clients
-        should connect to.
-        """
-        return "http://localhost:%d" % self.port
-
-    def create_proxy(self, params={}):
-        """
-        Gets a client class that allow to set all the proxy details that you
-        may need to.
-        :param params: Dictionary where you can specify params \
-                    like httpProxy and httpsProxy
-        """
-        client = Client(self.url[7:], params)
-        return client
-
-    def _is_listening(self):
-        try:
-            socket_ = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            socket_.settimeout(1)
-            socket_.connect(("localhost", self.port))
-            socket_.close()
-            return True
-        except socket.error:
-            return False


### PR DESCRIPTION
This patch makes it possible to use a remote proxy server, without the
need to have the `browserproxy-mob` executable locally.