### PR TITLE
fix broken test (test_new_page_defaults)

### DIFF
--- a/test/test_client.py
+++ b/test/test_client.py
@@ -64,7 +64,7 @@ class TestClient(object):
         self.client.new_page()
         har = self.client.har
         assert(len(har["log"]["pages"]) == 2)
-        assert(har["log"]["pages"][1]["id"] == "Page 2")
+        assert(har["log"]["pages"][1]["id"] == "Page 1")
 
     def test_new_named_page(self):
         """


### PR DESCRIPTION
I'm not very familiar with the HAR stuff, but it seems like browsermob creates pages starting at 0 now (vs 1)?

```
EX10346:~/git/browsermob-proxy-py (add_test_directions) > py.test test/test_client.py --pdb
====================================================================== test session starts =======================================================================
platform darwin -- Python 2.7.9 -- py-1.4.29 -- pytest-2.7.2
rootdir: /Users/aje/code/browsermob-proxy-py, inifile: 
collected 1 items 

test/test_client.py F
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> traceback >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

self = <test_client.TestClient object at 0x10efd6cd0>

    def test_new_page_defaults(self):
        """
            /proxy/:port/pageRef
            adds a new page of 'Page N' when no page name is given
            """
        # import ipdb; ipdb.set_trace()
        self.client.new_har()
        self.client.new_page()
        har = self.client.har
        assert(len(har["log"]["pages"]) == 2)
>       assert(har["log"]["pages"][1]["id"] == "Page 2")
E       assert 'Page 1' == 'Page 2'
E         - Page 1
E         ?      ^
E         + Page 2
E         ?      ^

test/test_client.py:68: AssertionError
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> entering PDB >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
> /Users/aje/code/browsermob-proxy-py/test/test_client.py(68)test_new_page_defaults()
-> assert(har["log"]["pages"][1]["id"] == "Page 2")
(Pdb) har
{u'log': {u'comment': u'', u'entries': [], u'version': u'1.2', u'pages': [{u'pageTimings': {u'comment': u''}, u'comment': u'', u'title': u'Page 0', u'id': u'Page 0', u'startedDateTime': u'2015-06-24T19:48:57.130-07:00'}, {u'pageTimings': {u'comment': u''}, u'comment': u'', u'title': u'Page 1', u'id': u'Page 1', u'startedDateTime': u'2015-06-24T19:48:57.132-07:00'}], u'creator': {u'comment': u'', u'version': u'2.1.0-beta-1-legacy', u'name': u'BrowserMob Proxy'}}}
(Pdb) 
```