### PR TITLE
Change remap_hosts to accept dictionary

### DIFF
--- a/browsermobproxy/client.py
+++ b/browsermobproxy/client.py
@@ -279,7 +279,7 @@ class Client(object):
             raise TypeError("hostmap needs to be a dictionary")
   
         if not hostmap:
-            raise Error("hostmap should have at least one entry")
+            raise Exception("hostmap should have at least one entry")
   
         r = requests.post('%s/proxy/%s/hosts' % (self.host, self.port),
                          json.dumps(hostmap),

--- a/browsermobproxy/client.py
+++ b/browsermobproxy/client.py
@@ -269,17 +269,19 @@ class Client(object):
                          params)
         return r.status_code
 
-    def remap_hosts(self, address, ip_address):
+    def remap_hosts(self, hostmap):
         """
         Remap the hosts for a specific URL
 
-
-        :param address: url that you wish to remap
-        :param ip_address: IP Address that will handle all traffic for the address passed in
+        :param hostmap: A dictionary of url/ip_address pairs to remap
         """
-        assert address is not None and ip_address is not None
+        if not isinstance(hostmap, dict):
+            raise TypeError("hostmap needs to be a dictionary")
+        
+        if not hostmap:
+            raise Error("hostmap should have at least one entry")
         r = requests.post('%s/proxy/%s/hosts' % (self.host, self.port),
-                         json.dumps({address: ip_address}),
+                         json.dumps(hostmap),
                           headers={'content-type': 'application/json'})
         return r.status_code
 

--- a/browsermobproxy/client.py
+++ b/browsermobproxy/client.py
@@ -277,9 +277,10 @@ class Client(object):
         """
         if not isinstance(hostmap, dict):
             raise TypeError("hostmap needs to be a dictionary")
-        
+  
         if not hostmap:
             raise Error("hostmap should have at least one entry")
+  
         r = requests.post('%s/proxy/%s/hosts' % (self.host, self.port),
                          json.dumps(hostmap),
                           headers={'content-type': 'application/json'})

--- a/browsermobproxy/client.py
+++ b/browsermobproxy/client.py
@@ -281,18 +281,18 @@ class Client(object):
                          params)
         return r.status_code
 
-    def remap_hosts(self, hostmap):
+    def remap_hosts(self, address=None, ip_address=None, hostmap={}):
         """
         Remap the hosts for a specific URL
 
-        :param hostmap: A dictionary of url/ip_address pairs to remap
+        :param address: url that you wish to remap
+        :param ip_address: IP Address that will handle all traffic for the address passed in
+        :param **hostmap: Other hosts to be added as keyword arguments
         """
-        if not isinstance(hostmap, dict):
-            raise TypeError("hostmap needs to be a dictionary")
-  
-        if not hostmap:
-            raise Exception("hostmap should have at least one entry")
-  
+
+        if (address is not None and ip_address is not None):
+            hostmap[address] = ip_address
+
         r = requests.post('%s/proxy/%s/hosts' % (self.host, self.port),
                          json.dumps(hostmap),
                           headers={'content-type': 'application/json'})

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -215,7 +215,7 @@ class TestClient(object):
         """
         /proxy/:port/hosts
         """
-        status_code = self.client.remap_hosts("example.com", "1.2.3.4")
+        status_code = self.client.remap_hosts({"example.com": "1.2.3.4"})
         assert(status_code == 200)
 
     def test_wait_for_traffic_to_stop(self):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -225,7 +225,14 @@ class TestClient(object):
         """
         /proxy/:port/hosts
         """
-        status_code = self.client.remap_hosts({"example.com": "1.2.3.4"})
+        status_code = self.client.remap_hosts("example.com", "1.2.3.4")
+        assert(status_code == 200)
+
+    def test_remap_hosts_with_hostmap(self):
+        """
+        /proxy/:port/hosts
+        """
+        status_code = self.client.remap_hosts(hostmap={"example.com": "1.2.3.4"})
         assert(status_code == 200)
 
     def test_wait_for_traffic_to_stop(self):


### PR DESCRIPTION
```remap_hosts``` should allow multiple hosts to be remapped at once. In order to achieve it should take a dictionary argument instead of a single url/address pair.