### PR TITLE
Make sure the Java process is still running while waiting for the server to start

### DIFF
--- a/browsermobproxy/server.py
+++ b/browsermobproxy/server.py
@@ -97,6 +97,10 @@ class Server(RemoteServer):
                                         stderr=subprocess.STDOUT)
         count = 0
         while not self._is_listening():
+            if self.process.poll():
+                message = ("The Browsermob-Proxy server process failed to start. Check server.log "
+                           "for a helpful error message.")
+                raise Exception(message)
             time.sleep(0.5)
             count += 1
             if count == 60:


### PR DESCRIPTION
I've noticed that when Server.start() is invoked and the Java process immediately fails (e.g. due to problems with the Java environment), the start() function continues waiting for the server to begin listening, until the ~30 second timeout expires.

It's no big deal in the grand scheme of things, but I thought it would be nice to have immediate feedback for the user in this case where the server is clearly not going to start.