### PR TITLE
Improve Error Message When Starting Server

### DIFF
--- a/browsermobproxy/client.py
+++ b/browsermobproxy/client.py
@@ -29,7 +29,12 @@ class Client(object):
             self.port = options['existing_proxy_port_to_use']
         else:
             resp = requests.post('%s/proxy' % self.host + urlparams)
-            jcontent = json.loads(resp.content.decode('utf-8'))
+            content = resp.content.decode('utf-8')
+            try:
+                jcontent = json.loads(content)
+            except Exception as e:
+                raise Exception("Could not read Browsermob-Proxy json\n"
+                    "Another server running on this port?\n%s..."%content[:512])
             self.port = jcontent['port']
         url_parts = self.host.split(":")
         self.proxy = url_parts[1][2:] + ":" + str(self.port)


### PR DESCRIPTION
If the JSON doesn't load, it's likely because the user has another server running on the same port. Improve the error message here so can figure out what's going on more easily.

This is definitely a newbie mistake, but it's nice to have better error messages.