### PR TITLE
Check to see if Server is Running Before Starting New

### DIFF
--- a/browsermobproxy/client.py
+++ b/browsermobproxy/client.py
@@ -29,7 +29,12 @@ class Client(object):
             self.port = options['existing_proxy_port_to_use']
         else:
             resp = requests.post('%s/proxy' % self.host + urlparams)
-            jcontent = json.loads(resp.content.decode('utf-8'))
+            content = resp.content.decode('utf-8')
+            try:
+                jcontent = json.loads(content)
+            except Exception as e:
+                raise Exception("Could not read Browsermob-Proxy json\n"
+                    "Another server running on this port?\n%s..."%content[:512])
             self.port = jcontent['port']
         url_parts = self.host.split(":")
         self.proxy = url_parts[1][2:] + ":" + str(self.port)

--- a/browsermobproxy/server.py
+++ b/browsermobproxy/server.py
@@ -3,6 +3,7 @@ import platform
 import socket
 import subprocess
 import time
+import logging
 
 from .client import Client
 from .exceptions import ProxyServerError
@@ -40,10 +41,10 @@ class RemoteServer(object):
         client = Client(self.url[7:], params)
         return client
 
-    def _is_listening(self):
+    def _is_listening(self, timeout = 1):
         try:
             socket_ = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            socket_.settimeout(1)
+            socket_.settimeout(timeout)
             socket_.connect((self.host, self.port))
             socket_.close()
             return True
@@ -108,6 +109,10 @@ class Server(RemoteServer):
         log_path_name = os.path.join(log_path, log_file)
         self.log_file = open(log_path_name, 'w')
 
+        if self._is_listening(.1):
+            logging.info("BrowserMob proxy already running. Won't start again.")
+            return
+        
         self.process = subprocess.Popen(self.command,
                                         stdout=self.log_file,
                                         stderr=subprocess.STDOUT)


### PR DESCRIPTION
Before starting a new Browserproy server, check to see if the server is running. If it is, then just use the existing server rather than starting a new one. This can be helpful if you're running in a multiprocess or threaded environment and many different clients want to use the server simultaneously.