### PR TITLE
specify host as option with localhost as default

### DIFF
--- a/browsermobproxy/server.py
+++ b/browsermobproxy/server.py
@@ -81,7 +81,7 @@ class Server(RemoteServer):
                                    "in path provided: %s" % path)
 
         self.path = path
-        self.host = 'localhost'
+        self.host = options.get('host', 'localhost')
         self.port = options.get('port', 8080)
         self.process = None
 


### PR DESCRIPTION
When the proxy is running on another server than localhost, this allows to specify the host to connect to